### PR TITLE
IDS uses a map + module manager get user fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 log
 lib/
 resources/IDS_PRIVATE
+resources/IDS_PUBLIC_DEV
 resources/responses/
 response-manager/sounds/
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ For security reasons, the API is stored in `resources/IDS_PRIVATE` which is incl
 `resources/IDS_PRIVATE` in the format described below. Whitespace on either side of the semicolon
 is ignored.
 
+### Public IDs
+
+By default, the bot reads `resources/IDS_PUBLIC` for public IDs. But for testing the bot on your own server,
+you're going to have to change these values. To do this, please copy the file into `resources/IDS_PUBLIC_DEV` and
+change the values in there. Then, when running the bot on your own server, pass in the command line argument
+`IDS_PUBLIC_DEV`.
+
 ```
 API_KEY : ABCDE.ABCDE
 ```
@@ -21,7 +28,7 @@ the `ResponseManager`.
 
 The build script is [`build.gradle.kts`](build.gradle.kts) which is written with the Kotlin DSL for
 Gradle. You can use the `run` build target (`gradle run`) for testing and debugging, but
-the `shadowJar` target is used for deployment.
+the `shadowJar` target is used for deployment. Make sure to also set `IDS_PUBLIC_DEV` for Program Arguments.
 
 # Structure
 

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -16,17 +16,17 @@ import kotlin.system.exitProcess
 @ExperimentalPathApi
 fun main() {
 	try {
-		val bot = Bot(IDS.getID("DPACK_GUILD")!!)
+		val bot = Bot(IDS.get("DPACK_GUILD")!!)
 		bot.addModule(ModuleManagerModule())
 		bot.addModule(ResponseModule())
-		bot.addModule(AmongUsModule(IDS.getID("AMONG_US_TEXT_CHANNEL")!!))
-		bot.addModule(VCModule(IDS.getID("VC_ROLE")!!, IDS.getID("VC_TEXT_CHANNEL")!!))
+		bot.addModule(AmongUsModule(IDS.get("AMONG_US_TEXT_CHANNEL")!!))
+		bot.addModule(VCModule(IDS.get("VC_ROLE")!!, IDS.get("VC_TEXT_CHANNEL")!!))
 		bot.addModule(PseudoAdminModule())
 		bot.addModule(WiggleModule())
-		bot.addModule(RoleManagerModule(IDS.getID("ROLE_TOGGLE_MESSAGE")!!, IDS.getID("ROLE_TOGGLE_CHANNEL")!!, "resources/roles"))
+		bot.addModule(RoleManagerModule(IDS.get("ROLE_TOGGLE_MESSAGE")!!, IDS.get("ROLE_TOGGLE_CHANNEL")!!, "resources/roles"))
 		bot.addModule(
 			WelcomeModule(FileReader("resources/welcome-message.txt").readText(),
-				IDS.getID("MEMBER_ROLE")!!))
+				IDS.get("MEMBER_ROLE")!!))
 		bot.startup()
 	} catch (e : Exception) {
 		Logger.logError(e)

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -14,7 +14,10 @@ import kotlin.io.path.ExperimentalPathApi
 import kotlin.system.exitProcess
 
 @ExperimentalPathApi
-fun main() {
+fun main(args: Array<String>) {
+	/* call with a command line argument to redirect the IDS_PUBLIC file */
+	IDS.init(args.getOrNull(0))
+
 	try {
 		val bot = Bot(IDS.get("DPACK_GUILD")!!)
 		bot.addModule(ModuleManagerModule())

--- a/src/main/kotlin/bot/Bot.kt
+++ b/src/main/kotlin/bot/Bot.kt
@@ -7,6 +7,8 @@ import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.requests.GatewayIntent
+import net.dv8tion.jda.api.utils.MemberCachePolicy
+import net.dv8tion.jda.api.utils.cache.CacheFlag
 import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
@@ -18,8 +20,9 @@ import kotlin.reflect.KFunction
 @Suppress("UNCHECKED_CAST")
 class Bot(targetGuildSnowflake : String) {
 
-	private var jdaBuilder : JDABuilder? = JDABuilder.createDefault(IDS.getID("API_KEY"))
+	private var jdaBuilder : JDABuilder? = JDABuilder.createDefault(IDS.get("API_KEY"))
 		.enableIntents(GatewayIntent.GUILD_MEMBERS)
+		.setMemberCachePolicy(MemberCachePolicy.ONLINE)
 
 	private var jdaObj : JDA? = null
 
@@ -43,9 +46,7 @@ class Bot(targetGuildSnowflake : String) {
 		jdaObj = jdaBuilder!!.build().awaitReady()
 		jdaBuilder = null
 
-		for (module in modules.clone() as List<*>) {
-			(module as IModule).onStartup(this)
-		}
+		modules.forEach { it.onStartup(this) }
 
 		Logger.info("bot is now running!")
 	}

--- a/src/main/kotlin/bot/Bot.kt
+++ b/src/main/kotlin/bot/Bot.kt
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.requests.GatewayIntent
 import net.dv8tion.jda.api.utils.MemberCachePolicy
 import net.dv8tion.jda.api.utils.cache.CacheFlag
 import java.util.*
+import kotlin.collections.ArrayList
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 
@@ -46,7 +47,7 @@ class Bot(targetGuildSnowflake : String) {
 		jdaObj = jdaBuilder!!.build().awaitReady()
 		jdaBuilder = null
 
-		modules.forEach { it.onStartup(this) }
+		ArrayList(modules).forEach { it.onStartup(this) }
 
 		Logger.info("bot is now running!")
 	}

--- a/src/main/kotlin/bot/IDS.kt
+++ b/src/main/kotlin/bot/IDS.kt
@@ -21,11 +21,12 @@ object IDS {
 		fileReader.close()
 	}
 
-	init {
+	fun init(publicFile: String?) {
+		val publicFilename = "resources/${publicFile ?: "IDS_PUBLIC"}"
 		try {
-			collectFromFile("resources/IDS_PUBLIC")
+			collectFromFile(publicFilename)
 		} catch (_ : FileNotFoundException) {
-			Logger.warn("public IDS file missing, this will likely cause many problems, make sure there is a resources/IDS_PUBLIC in the working directory")
+			Logger.warn("public IDS file missing, this will likely cause many problems, make sure there is a $publicFilename in the working directory")
 		}
 
 		try {

--- a/src/main/kotlin/bot/IDS.kt
+++ b/src/main/kotlin/bot/IDS.kt
@@ -2,51 +2,37 @@ package bot
 
 import java.io.FileNotFoundException
 import java.io.FileReader
-import java.util.*
 
 /**
  * object that stores constants, specifically Discord snowflakes for the most part
  * @author Varas#5480
  */
 object IDS {
+	private var map = HashMap<String, String>()
 
-	private var names : Array<String>
+	private fun collectFromFile(filename: String) {
+		val fileReader = FileReader(filename)
 
-	private var values : Array<String>
+		fileReader.forEachLine { line ->
+			if (line.contains(":"))
+				map[line.substringBefore(':').trim()] = line.substringAfter(":").trim()
+		}
+
+		fileReader.close()
+	}
 
 	init {
-		val tempNames = ArrayList<String>()
-		val tempValues = ArrayList<String>()
-
 		try {
-			val fr = FileReader("resources/IDS_PUBLIC")
-
-			fr.forEachLine { line ->
-				if (line.contains(":")) {
-					tempNames.add(line.substringBefore(':').trim())
-					tempValues.add(line.substringAfter(":").trim())
-				}
-			}
-			fr.close()
+			collectFromFile("resources/IDS_PUBLIC")
 		} catch (_ : FileNotFoundException) {
 			Logger.warn("public IDS file missing, this will likely cause many problems, make sure there is a resources/IDS_PUBLIC in the working directory")
 		}
 
 		try {
-			val fr = FileReader("resources/IDS_PRIVATE")
-
-			fr.forEachLine { line ->
-				if (line.contains(":")) {
-					tempNames.add(line.substringBefore(':').trim())
-					tempValues.add(line.substringAfter(":").trim())
-				}
-			}
+			collectFromFile("resources/IDS_PRIVATE")
 		} catch (_ : FileNotFoundException) {
 			Logger.warn("private IDS file missing, this will likely cause many problems, make sure there is a resources/IDS_PRIVATE in the working directory")
 		}
-
-		names = Array(tempNames.size) {i -> tempNames[i]}
-		values = Array(tempValues.size) {i -> tempValues[i]}
 	}
 
 	/**
@@ -54,12 +40,5 @@ object IDS {
 	 * @param name name of the ID
 	 * @return value of the ID, will be null if there is not an ID with the given name
 	 */
-	fun getID(name : String) : String? {
-		names.forEachIndexed {i, n ->
-			if (name == n) {
-				return values[i]
-			}
-		}
-		return null
-	}
+	fun get(name : String) = map[name]
 }

--- a/src/main/kotlin/modules/WiggleModule.kt
+++ b/src/main/kotlin/modules/WiggleModule.kt
@@ -14,7 +14,7 @@ class WiggleModule : ListenerModule() {
 		get() = "Wiggle"
 
 	override fun load() : Boolean {
-		return super.load() && IDS.getID("WIGGLE") != null
+		return super.load() && IDS.get("WIGGLE") != null
 	}
 
 	@SlashCommand("wiggle", "wOggle")
@@ -22,7 +22,7 @@ class WiggleModule : ListenerModule() {
 	           @CMDParam("id of the message you wish to wiggle") messageId : Long = 0L) {
 		var target = e.channel.getHistoryAround(e.messageChannel.latestMessageId, 1).complete().retrievedHistory[0]
 		target = e.channel.getHistoryAround(messageId, 1).complete().getMessageById(messageId) ?: target
-		target.addReaction(bot.getGuild().getEmoteById(IDS.getID("WIGGLE")!!)!!).complete()
+		target.addReaction(bot.getGuild().getEmoteById(IDS.get("WIGGLE")!!)!!).complete()
 		e.reply("w0ggle").flatMap { it.deleteOriginal() }.complete()
 	}
 
@@ -31,7 +31,7 @@ class WiggleModule : ListenerModule() {
 		val m = event.channel.getHistoryAround(event.messageId, 1).complete()
 			.getMessageById(event.messageId) ?: return
 		for (reaction in m.reactions.filter { it.reactionEmote.isEmote }
-			.filter {it.reactionEmote.id == IDS.getID("WIGGLE")!!}) {
+			.filter {it.reactionEmote.id == IDS.get("WIGGLE")!!}) {
 			reaction.removeReaction().complete()
 		}
 	}

--- a/src/main/kotlin/modules/moduleManager/ModuleManagerModule.kt
+++ b/src/main/kotlin/modules/moduleManager/ModuleManagerModule.kt
@@ -7,6 +7,7 @@ import bot.modules.IModule
 import bot.modules.ModuleID
 import net.dv8tion.jda.api.entities.User
 import org.reflections.Reflections
+import java.lang.RuntimeException
 import kotlin.reflect.KClass
 import kotlin.text.StringBuilder
 
@@ -23,16 +24,14 @@ class ModuleManagerModule : BotModule() {
 	}
 
 	override fun load(): Boolean {
-		return IDS.getID("MANAGER") != null
+		return IDS.get("MANAGER") != null
 	}
 
 	override fun onStartup(bot : Bot) : Boolean {
-		val manager = bot.getGuild().jda.getUserById(IDS.getID("MANAGER")!!)
-		if (manager == null) {
+		this.manager = bot.getGuild().jda.retrieveUserById(IDS.get("MANAGER")!!).complete()
+
+		if (this.manager == null)
 			Logger.error("Module Manager failed to find a MANAGER to send messages to")
-		} else {
-			this.manager = manager
-		}
 
 		sendManagerMessage("Module \"$name\" has been added\nid: $id")
 		return super.onStartup(bot)


### PR DESCRIPTION
The IDS class should be a lot cleaner now. The `getID()` function has been renamed to just `get()` because you're already calling it on `IDS`.

Also the module manager should always be able to get the user at startup now. Before it could fail if the cache wasn't generated in time.,